### PR TITLE
Version 9.15.2 is register but does not exist on npm SFINT-2145

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/shelljs": "0.7.7",
     "fs-extra": "^5.0.0",
     "handlebars": "^4.0.6",
-    "highlight.js": "^9.0.0",
+    "highlight.js": "~9.12.0",
     "lodash": "^4.13.1",
     "marked": "^0.3.12",
     "minimatch": "^3.0.0",


### PR DESCRIPTION
Lock the current real version of the lib.