### PR TITLE
Generating constrained values from union types of non-array options

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -338,7 +338,7 @@ export class Application extends ChildableComponent<Application, AbstractCompone
             values = copy;
         }
 
-        return values.slice(0, 4);
+        return values;
     }
 
     private getConstrainedValuesFromTypes(str: any) {

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -312,25 +312,38 @@ export class Application extends ChildableComponent<Application, AbstractCompone
     }
 
     private generateConstrainedValues(str: any) {
-        let constrainedValues = [];
-
-        if (str && str['type'] && str['type'].type == 'union') {
-            if (str.type.types[1] && str.type.types[1].elementType && str.type.types[1].elementType.types) {
-                constrainedValues = str.type.types[1].elementType.types.map(function (type) {
-                    return type.value;
-                });
-                if (str.type.types[0].type && str.type.types[0].type.toLowerCase() == 'array') {
-                    var copy = [];
-                    for (var i = 0; i < constrainedValues.length; i++) {
-                        copy[i] = constrainedValues.slice(0, i + 1).join(',');
-                    }
-                    constrainedValues = copy;
-                }
-                constrainedValues = constrainedValues.slice(0, 4);
-            }
+        if (!str || !str['type'] || !(str['type'].type == 'union')) {
+            return [];
         }
 
-        return constrainedValues;
+        if (str.type.types[1] && str.type.types[1].elementType && str.type.types[1].elementType.types) {
+           return this.getConstrainedValuesFromElementType(str);
+        }
+
+        if (str.type.types) {
+            return this.getConstrainedValuesFromTypes(str);
+        }
+
+        return [];
+    }
+
+    private getConstrainedValuesFromElementType(str: any) {
+        let values = str.type.types[1].elementType.types.map(type => type.value);
+
+        if (str.type.types[0].type && str.type.types[0].type.toLowerCase() == 'array') {
+            var copy = [];
+            for (var i = 0; i < values.length; i++) {
+                copy[i] = values.slice(0, i + 1).join(',');
+            }
+            values = copy;
+        }
+
+        return values.slice(0, 4);
+    }
+
+    private getConstrainedValuesFromTypes(str: any) {
+        const valuesAsString = str.type.types.filter(type => type.value).map(type => type.value).join(',');
+        return valuesAsString ? [valuesAsString] : [];
     }
 
     private generateMiscAttributes(str: any) {


### PR DESCRIPTION
With this PR, typedoc will generate constrained values for any union type. In order to be consistent with the list option, I joined the values with a `,` and returned the resulting string inside of an array.